### PR TITLE
Add security policy for responsible disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities in NASAAS seriously. If you believe you have found a security vulnerability, please report it to us as described below.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to the repository maintainer. Please include the following information in your report:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit it
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+We will respond to your report within 48 hours with our evaluation of the report and an expected resolution timeline.


### PR DESCRIPTION
This PR adds a comprehensive security policy to establish a clear process for reporting security vulnerabilities.

**Changes:**
- Added SECURITY.md with vulnerability reporting guidelines
- Established supported version information
- Created clear communication channels for security issues

**Benefits:**
- Improves project security posture
- Provides clear guidelines for security researchers
- Follows GitHub security best practices
- Enhances project credibility and trust

This is a standard practice for professional open source projects and will help protect both the project and its users.